### PR TITLE
ignore_errors on download

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
     remote_src: true
     extra_opts:
       - --strip-components=1
+  ignore_errors: yes
   tags:
     - nginx
     - geoip
@@ -34,6 +35,7 @@
     get_url:
       url: "{{ ngx_http_geoip2_module_source }}"
       dest: /opt/master.zip
+    ignore_errors: yes
     tags:
       - nginx
       - geoip
@@ -60,6 +62,7 @@
     get_url:
       url: "http://nginx.org/download/nginx-{{ nginx_version.stdout }}.tar.gz"
       dest: "/opt/nginx-{{ nginx_version.stdout }}.tar.gz"
+    ignore_errors: yes
     tags:
       - nginx
       - geoip


### PR DESCRIPTION
Avoid error if the download fail.
Usefull when the setup have already been done and ansible is run again.